### PR TITLE
feat(MnnLlmChat): CDN auto-upload via ali-oss, upload-market-config script

### DIFF
--- a/apps/Android/MnnLlmChat/.gitignore
+++ b/apps/Android/MnnLlmChat/.gitignore
@@ -5,6 +5,7 @@ toc.pb
 release_outputs/
 .kotlin/
 tests/smoke/artifacts/
+node_modules/
 
 # Model configuration files (contains internal URLs)
 model-config.json

--- a/apps/Android/MnnLlmChat/package-lock.json
+++ b/apps/Android/MnnLlmChat/package-lock.json
@@ -1,0 +1,966 @@
+{
+  "name": "mnnllmchat-android",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mnnllmchat-android",
+      "version": "0.0.0",
+      "dependencies": {
+        "ali-oss": "^6.23.0"
+      }
+    },
+    "node_modules/address": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
+      "integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.3.tgz",
+      "integrity": "sha512-yqXL+k5rr8+ZRpOAntkaaRgWgE5o8ESAj5DyRmVTCSoZxXmqemb9Dd7T4i5UzwuERdLAJUy6XzR9zFVuf0kzkw==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/ali-oss": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/ali-oss/-/ali-oss-6.23.0.tgz",
+      "integrity": "sha512-FipRmyd16Pr/tEey/YaaQ/24Pc3HEpLM9S1DRakEuXlSLXNIJnu1oJtHM53eVYpvW3dXapSjrip3xylZUTIZVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "address": "^1.2.2",
+        "agentkeepalive": "^3.4.1",
+        "bowser": "^1.6.0",
+        "copy-to": "^2.0.1",
+        "dateformat": "^2.0.0",
+        "debug": "^4.3.4",
+        "destroy": "^1.0.4",
+        "end-or-error": "^1.0.1",
+        "get-ready": "^1.0.0",
+        "humanize-ms": "^1.2.0",
+        "is-type-of": "^1.4.0",
+        "js-base64": "^2.5.2",
+        "jstoxml": "^2.0.0",
+        "lodash": "^4.17.21",
+        "merge-descriptors": "^1.0.1",
+        "mime": "^2.4.5",
+        "platform": "^1.3.1",
+        "pump": "^3.0.0",
+        "qs": "^6.4.0",
+        "sdk-base": "^2.0.1",
+        "stream-http": "2.8.2",
+        "stream-wormhole": "^1.0.4",
+        "urllib": "^2.44.0",
+        "utility": "^1.18.0",
+        "xml2js": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
+    },
+    "node_modules/bowser": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
+      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ==",
+      "license": "MIT"
+    },
+    "node_modules/builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/copy-to": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/copy-to/-/copy-to-2.0.1.tgz",
+      "integrity": "sha512-3DdaFaU/Zf1AnpLiFDeNCD4TOWe3Zl2RZaTzUvWiIk5ERzcCodOE20Vqq4fzCbNoHURFHT4/us/Lfq+S2zyY4w==",
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/dateformat": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+      "integrity": "sha512-GODcnWq3YGoTnygPfi02ygEiRxqUxpJwuRHjdhJYuxpcZmDq4rjBiXYmbCCzStxo176ixfLT6i4NPwQooRySnw==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/default-user-agent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/default-user-agent/-/default-user-agent-1.0.0.tgz",
+      "integrity": "sha512-bDF7bg6OSNcSwFWPu4zYKpVkJZQYVrAANMYB8bc9Szem1D0yKdm4sa/rOCs2aC9+2GMqQ7KnwtZRvDhmLF0dXw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-name": "~1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/digest-header": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/digest-header/-/digest-header-1.1.0.tgz",
+      "integrity": "sha512-glXVh42vz40yZb9Cq2oMOt70FIoWiv+vxNvdKdU8CwjLad25qHM3trLxhl9bVjdr6WaslIXhWpn0NO8T/67Qjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/end-or-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/end-or-error/-/end-or-error-1.0.1.tgz",
+      "integrity": "sha512-OclLMSug+k2A0JKuf494im25ANRBVW8qsjmwbgX7lQ8P82H21PQ1PWkoYwb9y5yMBS69BPlwtzdIFClo3+7kOQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.11.14"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/formstream": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/formstream/-/formstream-1.5.2.tgz",
+      "integrity": "sha512-NASf0lgxC1AyKNXQIrXTEYkiX99LhCEXTkiGObXAkpBui86a4u8FjH1o2bGb3PpqI3kafC+yw4zWeK6l6VHTgg==",
+      "license": "MIT",
+      "dependencies": {
+        "destroy": "^1.0.4",
+        "mime": "^2.5.2",
+        "node-hex": "^1.0.1",
+        "pause-stream": "~0.0.11"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-ready": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-ready/-/get-ready-1.0.0.tgz",
+      "integrity": "sha512-mFXCZPJIlcYcth+N8267+mghfYN9h3EhsDa6JSnbA3Wrhh/XFpuowviFcsDeYZtKspQyWyJqfs4O6P8CHeTwzw==",
+      "license": "MIT"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-class-hotfix": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/is-class-hotfix/-/is-class-hotfix-0.0.6.tgz",
+      "integrity": "sha512-0n+pzCC6ICtVr/WXnN2f03TK/3BfXY7me4cjCAqT8TYXEl0+JBRoqBo94JJHXcyDSLUeWbNX8Fvy5g5RJdAstQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-type-of": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/is-type-of/-/is-type-of-1.4.0.tgz",
+      "integrity": "sha512-EddYllaovi5ysMLMEN7yzHEKh8A850cZ7pykrY1aNRQGn/CDjRDE9qEWbIdt7xGEVJmjBXzU/fNnC4ABTm8tEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "^1.0.2",
+        "is-class-hotfix": "~0.0.6",
+        "isstream": "~0.1.2"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "license": "MIT"
+    },
+    "node_modules/js-base64": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/jstoxml": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/jstoxml/-/jstoxml-2.2.9.tgz",
+      "integrity": "sha512-OYWlK0j+roh+eyaMROlNbS5cd5R25Y+IUpdl7cNdB8HNrkgwQzIS7L9MegxOiWNBj9dQhA/yAxiMwCC5mwNoBw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/node-hex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/node-hex/-/node-hex-1.0.1.tgz",
+      "integrity": "sha512-iwpZdvW6Umz12ICmu9IYPRxg0tOLGmU3Tq2tKetejCj3oZd7b2nUXwP3a7QA5M9glWy8wlPS1G3RwM/CdsUbdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/os-name": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
+      "integrity": "sha512-f5estLO2KN8vgtTRaILIgEGBoBrMnZ3JQ7W9TMZCnOIGwHe8TRGSpcagnWDo+Dfhd/z08k9Xe75hvciJJ8Qaew==",
+      "license": "MIT",
+      "dependencies": {
+        "osx-release": "^1.0.0",
+        "win-release": "^1.0.0"
+      },
+      "bin": {
+        "os-name": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/osx-release": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
+      "integrity": "sha512-ixCMMwnVxyHFQLQnINhmIpWqXIfS2YOXchwQrk+OFzmo6nDjQ0E4KXAyyUh0T0MZgV4bUhkRrAbVqlE4yLVq4A==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.1.0"
+      },
+      "bin": {
+        "osx-release": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/sdk-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sdk-base/-/sdk-base-2.0.1.tgz",
+      "integrity": "sha512-eeG26wRwhtwYuKGCDM3LixCaxY27Pa/5lK4rLKhQa7HBjJ3U3Y+f81MMZQRsDw/8SC2Dao/83yJTXJ8aULuN8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "get-ready": "~1.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/stream-http": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
+      "integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
+      "license": "MIT",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/stream-wormhole": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stream-wormhole/-/stream-wormhole-1.1.0.tgz",
+      "integrity": "sha512-gHFfL3px0Kctd6Po0M8TzEvt3De/xu6cnRrjlfYNhwbhLPLwigI2t1nc6jrzNuaYg5C4YF78PPFuQPzRiqn9ew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
+    },
+    "node_modules/to-arraybuffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA==",
+      "license": "MIT"
+    },
+    "node_modules/unescape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unescape/-/unescape-1.0.1.tgz",
+      "integrity": "sha512-O0+af1Gs50lyH1nUu3ZyYS1cRh01Q/kUKatTOkSs7jukXE6/NebucDVxyiDsA9AQ4JC1V1jUH9EO8JX2nMDgGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/urllib": {
+      "version": "2.44.0",
+      "resolved": "https://registry.npmjs.org/urllib/-/urllib-2.44.0.tgz",
+      "integrity": "sha512-zRCJqdfYllRDA9bXUtx+vccyRqtJPKsw85f44zH7zPD28PIvjMqIgw9VwoTLV7xTBWZsbebUFVHU5ghQcWku2A==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.3.0",
+        "content-type": "^1.0.2",
+        "default-user-agent": "^1.0.0",
+        "digest-header": "^1.0.0",
+        "ee-first": "~1.1.1",
+        "formstream": "^1.1.0",
+        "humanize-ms": "^1.2.0",
+        "iconv-lite": "^0.6.3",
+        "pump": "^3.0.0",
+        "qs": "^6.4.0",
+        "statuses": "^1.3.1",
+        "utility": "^1.16.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utility": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/utility/-/utility-1.18.0.tgz",
+      "integrity": "sha512-PYxZDA+6QtvRvm//++aGdmKG/cI07jNwbROz0Ql+VzFV1+Z0Dy55NI4zZ7RHc9KKpBePNFwoErqIuqQv/cjiTA==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-to": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "mkdirp": "^0.5.1",
+        "mz": "^2.7.0",
+        "unescape": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/win-release": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
+      "integrity": "sha512-iCRnKVvGxOQdsKhcQId2PXV1vV3J/sDPXKA4Oe9+Eti2nb2ESEsYHRYls/UjoUW3bIc5ZDO8dTH50A/5iVN+bw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/apps/Android/MnnLlmChat/package.json
+++ b/apps/Android/MnnLlmChat/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mnnllmchat-android",
+  "version": "0.0.0",
+  "private": true,
+  "description": "MnnLlmChat Android app - release scripts and CDN upload",
+  "type": "module",
+  "scripts": {
+    "upload:cdn": "node scripts/upload-cdn.mjs",
+    "upload:market-config": "node scripts/upload-market-config.mjs"
+  },
+  "dependencies": {
+    "ali-oss": "^6.23.0"
+  }
+}

--- a/apps/Android/MnnLlmChat/scripts/README.md
+++ b/apps/Android/MnnLlmChat/scripts/README.md
@@ -6,6 +6,8 @@ This directory contains scripts for building and releasing the MnnLlmChat Androi
 
 - `release.sh` - Main release script for building and publishing the app
 - `bump_version.sh` - Version bump helper for `versionName` and `versionCode`
+- `upload-cdn.mjs` - Upload APK to CDN (ali-oss)
+- `upload-market-config.mjs` - Upload `model_market.json` to OSS (`data/mnn/apis/model_market.json`)
 - `release.config.example` - Example configuration file
 - `setup_release.sh` - Setup script to help configure the release environment
 - `test_build.sh` - Test script to verify build commands work correctly
@@ -109,11 +111,17 @@ The script uses the following environment variables (can be set in `release.conf
 - `KEY_ALIAS` - Key alias
 - `KEY_PASSWORD` - Key password
 
-#### CDN Configuration
+#### CDN Configuration (automatic upload via ali-oss SDK)
+Set in `~/.zshrc` or `release.config`. No bucket/region defaults in codebase.
 - `CDN_ENDPOINT` - Aliyun OSS endpoint
 - `CDN_ACCESS_KEY` - Aliyun OSS access key ID
 - `CDN_SECRET_KEY` - Aliyun OSS access key secret
-- `CDN_BUCKET` - Aliyun OSS bucket name
+- `CDN_BUCKET` - OSS bucket name
+- `CDN_OSS_PREFIX` - (optional) OSS path prefix, default `data/mnn/apks`
+
+Upload path: `{CDN_OSS_PREFIX}/mnn_chat_{version}.apk`
+
+CDN upload uses Node.js + ali-oss SDK (no ossutil required). Run `npm install` once in the project root to install dependencies.
 
 #### Google Play Configuration
 - `GOOGLE_PLAY_SERVICE_ACCOUNT` - Path to Google Play service account JSON file

--- a/apps/Android/MnnLlmChat/scripts/oss-utils.mjs
+++ b/apps/Android/MnnLlmChat/scripts/oss-utils.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+/**
+ * OSS upload utilities for MnnLlmChat CDN release.
+ * Reference: oneday-code-feature/skills_worktree/scripts/lib/oss-utils.mjs
+ *
+ * Environment variables (compatible with release.config):
+ *   CDN_ENDPOINT   - e.g. https://oss-cn-hangzhou.aliyuncs.com
+ *   CDN_ACCESS_KEY - Aliyun access key ID
+ *   CDN_SECRET_KEY - Aliyun access key secret
+ *   CDN_BUCKET     - OSS bucket name
+ *
+ * Alternative (OneDay-style):
+ *   OSS_ACCESS_KEY_ID, OSS_ACCESS_KEY_SECRET, OSS_REGION, OSS_BUCKET
+ */
+
+import OSS from "ali-oss"
+
+function getOssConfig() {
+	const accessKeyId =
+		process.env.OSS_ACCESS_KEY_ID || process.env.CDN_ACCESS_KEY
+	const accessKeySecret =
+		process.env.OSS_ACCESS_KEY_SECRET || process.env.CDN_SECRET_KEY
+	const bucket = process.env.OSS_BUCKET || process.env.CDN_BUCKET
+	const endpoint = process.env.CDN_ENDPOINT || process.env.OSS_ENDPOINT
+	const region =
+		process.env.OSS_REGION || extractRegionFromEndpoint(endpoint)
+
+	return { accessKeyId, accessKeySecret, bucket, region }
+}
+
+/**
+ * Extract OSS region from endpoint (e.g. https://oss-cn-hangzhou.aliyuncs.com -> oss-cn-hangzhou)
+ */
+function extractRegionFromEndpoint(endpoint) {
+	if (!endpoint || typeof endpoint !== "string") return null
+	const m = endpoint.match(/oss-([a-z0-9-]+)\.aliyuncs\.com/i)
+	return m ? `oss-${m[1]}` : null
+}
+
+export function validateEnv() {
+	const { accessKeyId, accessKeySecret, bucket, region } = getOssConfig()
+	const missing = []
+	if (!accessKeyId) missing.push("CDN_ACCESS_KEY or OSS_ACCESS_KEY_ID")
+	if (!accessKeySecret) missing.push("CDN_SECRET_KEY or OSS_ACCESS_KEY_SECRET")
+	if (!bucket) missing.push("CDN_BUCKET or OSS_BUCKET")
+	if (!region) missing.push("CDN_ENDPOINT or OSS_REGION")
+	if (missing.length > 0) {
+		console.error("❌ Missing OSS env vars:", missing.join(", "))
+		console.error("   Add CDN_ACCESS_KEY, CDN_SECRET_KEY, CDN_BUCKET, CDN_ENDPOINT to ~/.zshrc")
+		process.exit(1)
+	}
+}
+
+export function createOssClient() {
+	const { accessKeyId, accessKeySecret, bucket, region } = getOssConfig()
+	return new OSS({
+		region,
+		accessKeyId,
+		accessKeySecret,
+		bucket,
+		authorizationV4: true,
+	})
+}
+
+/**
+ * Upload a local file to OSS.
+ * @param {string} ossPath - OSS object path (e.g. releases/0.8.1.3/mnn_chat_0_8_1_3.apk)
+ * @param {string} localFile - Local file path
+ * @returns {Promise<{url: string}>}
+ */
+export async function uploadFile(ossPath, localFile) {
+	const client = createOssClient()
+	console.log(`⬆️  Uploading ${localFile} -> oss://${getOssConfig().bucket}/${ossPath}`)
+	const result = await client.put(ossPath, localFile)
+	console.log(`✅ Uploaded: ${result.url}`)
+	return result
+}

--- a/apps/Android/MnnLlmChat/scripts/release.config.example
+++ b/apps/Android/MnnLlmChat/scripts/release.config.example
@@ -15,8 +15,8 @@ KEY_ALIAS=your_key_alias
 KEY_PASSWORD=your_key_password
 
 # CDN Configuration (Required for CDN uploads)
-# Aliyun OSS endpoint (e.g., https://oss-cn-hangzhou.aliyuncs.com)
-CDN_ENDPOINT=https://oss-cn-hangzhou.aliyuncs.com
+# Set in ~/.zshrc or here. No defaults in codebase.
+CDN_ENDPOINT=https://oss-cn-xxx.aliyuncs.com
 
 # Aliyun OSS access key ID
 CDN_ACCESS_KEY=your_access_key_id
@@ -26,6 +26,9 @@ CDN_SECRET_KEY=your_access_key_secret
 
 # Aliyun OSS bucket name
 CDN_BUCKET=your_bucket_name
+
+# OSS path prefix for APK (default: data/mnn/apks)
+# CDN_OSS_PREFIX=data/mnn/apks
 
 # Google Play Configuration (Required for Google Play uploads)
 # Path to Google Play service account JSON file

--- a/apps/Android/MnnLlmChat/scripts/release.sh
+++ b/apps/Android/MnnLlmChat/scripts/release.sh
@@ -184,29 +184,33 @@ upload_to_cdn() {
         return
     fi
     
-    log_info "Uploading to CDN..."
+    log_info "Uploading to CDN (ali-oss SDK)..."
     
-    # Check if ossutil is available (Aliyun OSS CLI tool)
-    if ! command -v ossutil &> /dev/null; then
-        log_warning "ossutil not found. Please install it to upload to CDN."
-        log_info "You can install ossutil from: https://www.alibabacloud.com/help/en/object-storage-service/latest/ossutil-installation"
+    # Ensure Node.js and dependencies are available
+    if ! command -v node &> /dev/null; then
+        log_warning "Node.js not found. Install Node.js to enable automatic CDN upload."
         return
     fi
     
-    # Configure ossutil
-    ossutil config -e "$CDN_ENDPOINT" -i "$CDN_ACCESS_KEY" -k "$CDN_SECRET_KEY"
+    if [[ ! -d "node_modules/ali-oss" ]]; then
+        log_info "Installing ali-oss for CDN upload..."
+        npm install --no-save ali-oss
+    fi
     
-    # Generate version-based filename for upload
     VERSION_FILENAME=$(echo "$VERSION_NAME" | sed 's/\./_/g')
     APK_FILENAME="mnn_chat_${VERSION_FILENAME}.apk"
-    
-    # Upload APK to CDN
     APK_FILE="$CDN_UPLOAD_DIR/$APK_FILENAME"
-    if [[ -f "$APK_FILE" ]]; then
-        ossutil cp "$APK_FILE" "oss://$CDN_BUCKET/releases/$VERSION_NAME/$APK_FILENAME"
-        log_success "APK uploaded to CDN: oss://$CDN_BUCKET/releases/$VERSION_NAME/$APK_FILENAME"
-    else
+    
+    if [[ ! -f "$APK_FILE" ]]; then
         log_error "APK file not found for CDN upload: $APK_FILE"
+        return
+    fi
+    
+    if node scripts/upload-cdn.mjs --apk "$APK_FILE" --version "$VERSION_NAME"; then
+        OSS_PREFIX="${CDN_OSS_PREFIX:-data/mnn/apks}"
+        log_success "APK uploaded to CDN: oss://$CDN_BUCKET/$OSS_PREFIX/$APK_FILENAME"
+    else
+        log_error "CDN upload failed"
     fi
 }
 

--- a/apps/Android/MnnLlmChat/scripts/upload-cdn.mjs
+++ b/apps/Android/MnnLlmChat/scripts/upload-cdn.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+/**
+ * MnnLlmChat CDN upload script (ali-oss SDK, no ossutil required).
+ * Reference: oneday-code-feature/skills_worktree/scripts/publish-vscode.mjs
+ *
+ * Usage:
+ *   node scripts/upload-cdn.mjs
+ *   node scripts/upload-cdn.mjs --apk release_outputs/cdn/mnn_chat_0_8_1_3.apk --version 0.8.1.3
+ *
+ * Environment: source scripts/release.config or set CDN_* / OSS_* env vars.
+ */
+
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { uploadFile, validateEnv } from "./oss-utils.mjs"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, "..")
+
+const CDN_UPLOAD_DIR = path.join(ROOT, "release_outputs", "cdn")
+// OSS path prefix, e.g. data/mnn/apks -> https://bucket.oss-cn-xxx.aliyuncs.com/data/mnn/apks/mnn_chat_0_8_1_3.apk
+const OSS_APK_PREFIX = process.env.CDN_OSS_PREFIX || process.env.OSS_APK_PREFIX || "data/mnn/apks"
+
+function parseArgs() {
+	const args = process.argv.slice(2)
+	let apkPath = null
+	let version = null
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === "--apk" && args[i + 1]) {
+			apkPath = path.resolve(ROOT, args[i + 1])
+			i++
+		} else if (args[i] === "--version" && args[i + 1]) {
+			version = args[i + 1]
+			i++
+		}
+	}
+	return { apkPath, version }
+}
+
+function getVersionFromGradle() {
+	const gradlePath = path.join(ROOT, "app", "build.gradle")
+	if (!fs.existsSync(gradlePath)) return null
+	const content = fs.readFileSync(gradlePath, "utf-8")
+	const m = content.match(/versionName\s+"([^"]+)"/)
+	return m ? m[1] : null
+}
+
+function findLatestApk(dir) {
+	if (!fs.existsSync(dir)) return null
+	const files = fs.readdirSync(dir).filter((f) => f.endsWith(".apk"))
+	if (files.length === 0) return null
+	const sorted = files.sort((a, b) => {
+		const statA = fs.statSync(path.join(dir, a))
+		const statB = fs.statSync(path.join(dir, b))
+		return statB.mtimeMs - statA.mtimeMs
+	})
+	return path.join(dir, sorted[0])
+}
+
+async function main() {
+	const { apkPath, version: versionArg } = parseArgs()
+
+	const apk = apkPath || findLatestApk(CDN_UPLOAD_DIR)
+	if (!apk || !fs.existsSync(apk)) {
+		console.error("❌ APK not found. Run release.sh first or pass --apk <path>")
+		process.exit(1)
+	}
+
+	const version = versionArg || getVersionFromGradle()
+	if (!version) {
+		console.error("❌ Version not found. Pass --version <x.y.z> or ensure app/build.gradle has versionName")
+		process.exit(1)
+	}
+
+	const versionFilename = version.replace(/\./g, "_")
+	const apkFilename = `mnn_chat_${versionFilename}.apk`
+	const ossPath = `${OSS_APK_PREFIX}/${apkFilename}`
+
+	console.log("📦 MnnLlmChat CDN upload")
+	console.log(`   APK: ${apk}`)
+	console.log(`   Version: ${version}`)
+	console.log(`   OSS path: ${ossPath}`)
+	console.log("")
+
+	validateEnv()
+	await uploadFile(ossPath, apk)
+
+	console.log("")
+	console.log("✅ CDN upload completed")
+}
+
+main().catch((err) => {
+	console.error("❌ Upload failed:", err.message)
+	process.exit(1)
+})

--- a/apps/Android/MnnLlmChat/scripts/upload-market-config.mjs
+++ b/apps/Android/MnnLlmChat/scripts/upload-market-config.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+/**
+ * Upload model_market.json to OSS (update market config).
+ *
+ * Usage:
+ *   node scripts/upload-market-config.mjs
+ *   node scripts/upload-market-config.mjs --dev
+ *   node scripts/upload-market-config.mjs --file app/src/main/assets/model_market.json
+ *
+ * OSS path: data/mnn/apis/model_market.json (or model_market_dev.json with --dev)
+ * Env: CDN_ACCESS_KEY, CDN_SECRET_KEY, CDN_BUCKET, CDN_ENDPOINT (~/.zshrc or release.config)
+ */
+
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { uploadFile, validateEnv } from "./oss-utils.mjs"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, "..")
+
+const DEFAULT_LOCAL = path.join(ROOT, "app", "src", "main", "assets", "model_market.json")
+
+function parseArgs() {
+	const args = process.argv.slice(2)
+	let localFile = DEFAULT_LOCAL
+	let ossPath = "data/mnn/apis/model_market.json"
+
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === "--file" && args[i + 1]) {
+			localFile = path.resolve(ROOT, args[i + 1])
+			i++
+		} else if (args[i] === "--dev") {
+			ossPath = "data/mnn/apis/model_market_dev.json"
+		}
+	}
+	return { localFile, ossPath }
+}
+
+async function main() {
+	const { localFile, ossPath } = parseArgs()
+
+	if (!fs.existsSync(localFile)) {
+		console.error("❌ File not found:", localFile)
+		process.exit(1)
+	}
+
+	console.log("📤 Update market config")
+	console.log(`   Local: ${localFile}`)
+	console.log(`   OSS:   ${ossPath}`)
+	console.log("")
+
+	validateEnv()
+	await uploadFile(ossPath, localFile)
+
+	console.log("")
+	console.log("✅ Market config updated")
+}
+
+main().catch((err) => {
+	console.error("❌ Upload failed:", err.message)
+	process.exit(1)
+})


### PR DESCRIPTION
## Changes (CDN upload only, 9 files)
- Replace ossutil with Node.js ali-oss SDK for APK upload
- OSS path: `data/mnn/apks/mnn_chat_X_Y_Z.apk`
- Add `scripts/oss-utils.mjs`, `upload-cdn.mjs`, `upload-market-config.mjs`
- `upload-market-config`: upload `model_market.json` to `data/mnn/apis/`, `--dev` for `model_market_dev.json`
- Env: CDN_ACCESS_KEY, CDN_SECRET_KEY, CDN_BUCKET, CDN_ENDPOINT (no defaults in codebase)

Replaces #13 (which accidentally included 10 other commits from pr-4263)

Made with [Cursor](https://cursor.com)